### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,3 @@
+language = "nodejs"
+  run = "npm start"
+  

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ https://node-express-api-endpoint.herokuapp.com/
 
 https://node-express-api-endpoint.herokuapp.com/items
 
+[![Run on Repl.it](https://repl.it/badge/github/mheerspink75/express-api-endpoint)](https://repl.it/github/mheerspink75/express-api-endpoint)
+


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).